### PR TITLE
Check for when attribute using getattr to ignore other report objects.

### DIFF
--- a/pytest_timer/plugin.py
+++ b/pytest_timer/plugin.py
@@ -98,7 +98,7 @@ def pytest_terminal_summary(terminalreporter):
         # no need to report deselected tests (-k EXPRESSION)
         if report_type == "deselected":
             continue
-        for rep in (r for r in reports if r.when == "call"):
+        for rep in (r for r in reports if getattr(r, "when", None) == "call"):
             if hasattr(rep, "duration"):
                 duration = rep.duration
                 color = _get_result_color(time_taken=duration)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import mock
 
 from _pytest.config.argparsing import Parser
@@ -123,5 +124,18 @@ class TestPlugin:
             [
                 mocker.call("[success] 60.08% 1: 3.0100s"),
                 mocker.call("[success] 20.16% 2: 1.0100s"),
+            ]
+        )
+
+    def test_pytest_terminal_summary_with_user_warning(self, mocker, tr_mock):
+        warnings.warn("Test Warning to be used in tests")
+
+        plugin.pytest_terminal_summary(terminalreporter=tr_mock)
+
+        tr_mock.write_line.assert_has_calls(
+            [
+                mocker.call("[success] 60.08% 1: 3.0100s"),
+                mocker.call("[success] 20.16% 2: 1.0100s"),
+                mocker.call("[success] 19.76% 3: 0.9900s"),
             ]
         )


### PR DESCRIPTION
Fixes #4 

I have used getattr but one possible solution would be to just check for TestReport but this can cause issues where other objects that have call but are not subclass of TestReport to fail.